### PR TITLE
Auto put down red sign and activate ai on summon

### DIFF
--- a/Dark Souls AI C/AIMethods.c
+++ b/Dark Souls AI C/AIMethods.c
@@ -254,7 +254,7 @@ static void ToggleEscape(Character * Player, Character * Phantom, JOYSTICK_POSIT
     long curTime = clock();
 
     if (curTime < startTimeDefense + 30){
-        iReport->bHats = 0x3;//left d pad
+        iReport->bHats = dleft;
     }
 
     if (curTime > startTimeDefense + 60){

--- a/Dark Souls AI C/AIMethods.c
+++ b/Dark Souls AI C/AIMethods.c
@@ -454,13 +454,14 @@ static void MoveUp(Character * Player, Character * Phantom, JOYSTICK_POSITION * 
     long curTime = clock();
     guiPrint(LocationState",0:move up time:%d", (curTime - startTimeAttack));
 
+    if (Player->locked_on && curTime < startTimeAttack + 40){
+        iReport->lButtons = r3;
+    }
+
     if (curTime < startTimeAttack + inputDelayForStopMove){
         longTuple move = angleToJoystick(angleFromCoordinates(Player->loc_x, Phantom->loc_x, Player->loc_y, Phantom->loc_y));
         iReport->wAxisX = move.first;
         iReport->wAxisY = move.second;
-        if (Player->locked_on){
-            iReport->lButtons = r3;
-        }
     }
 
     if (curTime > startTimeAttack + inputDelayForStopMove){

--- a/Dark Souls AI C/CharacterStruct.c
+++ b/Dark Souls AI C/CharacterStruct.c
@@ -6,52 +6,51 @@
 
 #define WeaponGhostHitTime 0.21//NOTE: this is curently hardcoded for gold tracer until i find a dynamic way
 
-void ReadPlayer(Character * c, HANDLE * processHandle, int characterId){
-    HANDLE processHandle_nonPoint = *processHandle;
+void ReadPlayer(Character * c, HANDLE processHandle, int characterId){
     //TODO read large block that contains all data, then parse in process
     //read x location
-    ReadProcessMemory(processHandle_nonPoint, (LPCVOID)(c->location_x_address), &(c->loc_x), 4, 0);
+    ReadProcessMemory(processHandle, (LPCVOID)(c->location_x_address), &(c->loc_x), 4, 0);
     guiPrint("%d,0:X:%f", characterId, c->loc_x);
     //read y location
-    ReadProcessMemory(processHandle_nonPoint, (LPCVOID)(c->location_y_address), &(c->loc_y), 4, 0);
+    ReadProcessMemory(processHandle, (LPCVOID)(c->location_y_address), &(c->loc_y), 4, 0);
     guiPrint("%d,1:Y:%f", characterId, c->loc_y);
     //read rotation of player
-    ReadProcessMemory(processHandle_nonPoint, (LPCVOID)(c->rotation_address), &(c->rotation), 4, 0);
+    ReadProcessMemory(processHandle, (LPCVOID)(c->rotation_address), &(c->rotation), 4, 0);
     //Player rotation is pi. 0 to pi,-pi to 0. Same as atan2
     //convert to radians, then to degrees
     c->rotation = (c->rotation + PI) * (180.0 / PI);
     guiPrint("%d,2:Rotation:%f", characterId, c->rotation);
     //read current animation type
-    ReadProcessMemory(processHandle_nonPoint, (LPCVOID)(c->animationType_address), &(c->animationType_id), 2, 0);
+    ReadProcessMemory(processHandle, (LPCVOID)(c->animationType_address), &(c->animationType_id), 2, 0);
     guiPrint("%d,3:Animation Type:%d", characterId, c->animationType_id);
     //read hp
-    ReadProcessMemory(processHandle_nonPoint, (LPCVOID)(c->hp_address), &(c->hp), 4, 0);
+    ReadProcessMemory(processHandle, (LPCVOID)(c->hp_address), &(c->hp), 4, 0);
     guiPrint("%d,4:HP:%d", characterId, c->hp);
     //read stamina
     if (c->stamina_address){
-        ReadProcessMemory(processHandle_nonPoint, (LPCVOID)(c->stamina_address), &(c->stamina), 4, 0);
+        ReadProcessMemory(processHandle, (LPCVOID)(c->stamina_address), &(c->stamina), 4, 0);
         guiPrint("%d,5:Stamina:%d", characterId, c->stamina);
     }
     //read what weapon they currently have in right hand
-    ReadProcessMemory(processHandle_nonPoint, (LPCVOID)(c->r_weapon_address), &(c->r_weapon_id), 4, 0);
+    ReadProcessMemory(processHandle, (LPCVOID)(c->r_weapon_address), &(c->r_weapon_id), 4, 0);
     guiPrint("%d,6:R Weapon:%d", characterId, c->r_weapon_id);
     //read what weapon they currently have in left hand
-    ReadProcessMemory(processHandle_nonPoint, (LPCVOID)(c->l_weapon_address), &(c->l_weapon_id), 4, 0);
+    ReadProcessMemory(processHandle, (LPCVOID)(c->l_weapon_address), &(c->l_weapon_id), 4, 0);
     guiPrint("%d,7:L Weapon:%d", characterId, c->l_weapon_id);
 
     //read if hurtbox is active on enemy weapon
     if (c->hurtboxActive_address){
         unsigned char hurtboxActiveState;
-        ReadProcessMemory(processHandle_nonPoint, (LPCVOID)(c->hurtboxActive_address), &hurtboxActiveState, 1, 0);
+        ReadProcessMemory(processHandle, (LPCVOID)(c->hurtboxActive_address), &hurtboxActiveState, 1, 0);
         if (hurtboxActiveState){
             c->subanimation = AttackSubanimationActiveDuringHurtbox;
         }
     }
     int animationid;
-    ReadProcessMemory(processHandle_nonPoint, (LPCVOID)(c->animationId_address), &animationid, 4, 0);
+    ReadProcessMemory(processHandle, (LPCVOID)(c->animationId_address), &animationid, 4, 0);
     //need a second one b/c the game has a second one. the game has a second one b/c two animations can overlap.
     int animationid2;
-    ReadProcessMemory(processHandle_nonPoint, (LPCVOID)(c->animationId2_address), &animationid2, 4, 0);
+    ReadProcessMemory(processHandle, (LPCVOID)(c->animationId2_address), &animationid2, 4, 0);
 
     //keep track of enemy animations in memory
     bool newAid = false;
@@ -108,7 +107,7 @@ void ReadPlayer(Character * c, HANDLE * processHandle, int characterId){
 
         if (curAnimationid){
             float animationTimer;
-            ReadProcessMemory(processHandle_nonPoint, (LPCVOID)(curAnimationTimer_address), &animationTimer, 4, 0);
+            ReadProcessMemory(processHandle, (LPCVOID)(curAnimationTimer_address), &animationTimer, 4, 0);
 
             //handle the timer not being reset to 0 as soon as a new animation starts
             if (newAid){
@@ -118,7 +117,7 @@ void ReadPlayer(Character * c, HANDLE * processHandle, int characterId){
             //sometimes, due to lag, dark souls cuts one animation short and makes the next's hurtbox timing later. handle this for the animations that do it.
             if (CombineLastAnimation(curAnimationid)){
                 float animationTimer2;
-                ReadProcessMemory(processHandle_nonPoint, (LPCVOID)(c->animationTimer2_address), &animationTimer2, 4, 0);
+                ReadProcessMemory(processHandle, (LPCVOID)(c->animationTimer2_address), &animationTimer2, 4, 0);
                 animationTimer += animationTimer2;
             }
 
@@ -165,7 +164,7 @@ void ReadPlayer(Character * c, HANDLE * processHandle, int characterId){
     //read if in ready state(can transition to another animation)
     if (c->readyState_address){
         unsigned char readyState;
-        ReadProcessMemory(processHandle_nonPoint, (LPCVOID)(c->readyState_address), &readyState, 1, 0);
+        ReadProcessMemory(processHandle, (LPCVOID)(c->readyState_address), &readyState, 1, 0);
         if(readyState){
             c->subanimation = SubanimationRecover;
         } /*else{ Not adding this now because it would lock out subanimations every time i move
@@ -177,17 +176,17 @@ void ReadPlayer(Character * c, HANDLE * processHandle, int characterId){
     //read the current velocity
     //player doesnt use this, and wont have the address set. enemy will
     if (c->velocity_address){
-        ReadProcessMemory(processHandle_nonPoint, (LPCVOID)(c->velocity_address), &(c->velocity), 4, 0);
+        ReadProcessMemory(processHandle, (LPCVOID)(c->velocity_address), &(c->velocity), 4, 0);
         guiPrint("%d,11:Velocity:%f", characterId, c->velocity);
     }
     //read if the player is locked on
     if (c->locked_on_address){
-        ReadProcessMemory(processHandle_nonPoint, (LPCVOID)(c->locked_on_address), &(c->locked_on), 1, 0);
+        ReadProcessMemory(processHandle, (LPCVOID)(c->locked_on_address), &(c->locked_on), 1, 0);
         guiPrint("%d,12:Locked On:%d", characterId, c->locked_on);
     }
     //read two handed state of player
     if (c->twoHanding_address){
-        ReadProcessMemory(processHandle_nonPoint, (LPCVOID)(c->twoHanding_address), &(c->twoHanding), 1, 0);
+        ReadProcessMemory(processHandle, (LPCVOID)(c->twoHanding_address), &(c->twoHanding), 1, 0);
         guiPrint("%d,13:Two Handing:%d", characterId, c->twoHanding);
     }
 }
@@ -202,4 +201,45 @@ void ReadPlayerDEBUGGING(Character * c, HANDLE * processHandle, ...){
     c->l_weapon_id = 900000;
     c->subanimation = SubanimationNeutral;
     c->velocity = 0;
+}
+
+void ReadPointerEndAddresses(HANDLE processHandle){
+    //add the pointer offsets to the address. This can be slow because its startup only
+    Enemy.location_x_address = FindPointerAddr(processHandle, Enemy_base_add, Enemy_loc_x_offsets_length, Enemy_loc_x_offsets);
+    Enemy.location_y_address = FindPointerAddr(processHandle, Enemy_base_add, Enemy_loc_y_offsets_length, Enemy_loc_y_offsets);
+    Enemy.rotation_address = FindPointerAddr(processHandle, Enemy_base_add, Enemy_rotation_offsets_length, Enemy_rotation_offsets);
+    Enemy.animationType_address = FindPointerAddr(processHandle, Enemy_base_add, Enemy_animationType_offsets_length, Enemy_animationType_offsets);
+    Enemy.hp_address = FindPointerAddr(processHandle, Enemy_base_add, Enemy_hp_offsets_length, Enemy_hp_offsets);
+    Enemy.stamina_address = 0;
+    Enemy.r_weapon_address = FindPointerAddr(processHandle, Enemy_base_add, Enemy_r_weapon_offsets_length, Enemy_r_weapon_offsets);
+    Enemy.l_weapon_address = FindPointerAddr(processHandle, Enemy_base_add, Enemy_l_weapon_offsets_length, Enemy_l_weapon_offsets);
+    Enemy.animationTimer_address = FindPointerAddr(processHandle, Enemy_base_add, Enemy_animationTimer_offsets_length, Enemy_animationTimer_offsets);
+    Enemy.animationTimer2_address = FindPointerAddr(processHandle, Enemy_base_add, Enemy_animationTimer2_offsets_length, Enemy_animationTimer2_offsets);
+    Enemy.animationId_address = FindPointerAddr(processHandle, Enemy_base_add, Enemy_animationID_offsets_length, Enemy_animationID_offsets);
+    Enemy.animationId2_address = FindPointerAddr(processHandle, Enemy_base_add, Enemy_animationID2_offsets_length, Enemy_animationID2_offsets);
+    Enemy.hurtboxActive_address = FindPointerAddr(processHandle, Enemy_base_add, Enemy_hurtboxActive_offsets_length, Enemy_hurtboxActive_offsets);
+    Enemy.readyState_address = 0;
+    Enemy.velocity_address = FindPointerAddr(processHandle, Enemy_base_add, Enemy_velocity_offsets_length, Enemy_velocity_offsets);
+    Enemy.locked_on_address = 0;
+    Enemy.twoHanding_address = 0;
+    Enemy.visualStatus_address = 0;
+
+    Player.location_x_address = FindPointerAddr(processHandle, player_base_add, Player_loc_x_offsets_length, Player_loc_x_offsets);
+    Player.location_y_address = FindPointerAddr(processHandle, player_base_add, Player_loc_y_offsets_length, Player_loc_y_offsets);
+    Player.rotation_address = FindPointerAddr(processHandle, player_base_add, Player_rotation_offsets_length, Player_rotation_offsets);
+    Player.animationType_address = FindPointerAddr(processHandle, player_base_add, Player_animationType_offsets_length, Player_animationType_offsets);
+    Player.hp_address = FindPointerAddr(processHandle, player_base_add, Player_hp_offsets_length, Player_hp_offsets);
+    Player.stamina_address = FindPointerAddr(processHandle, player_base_add, Player_stamina_offsets_length, Player_stamina_offsets);
+    Player.r_weapon_address = FindPointerAddr(processHandle, player_base_add, Player_r_weapon_offsets_length, Player_r_weapon_offsets);
+    Player.l_weapon_address = FindPointerAddr(processHandle, player_base_add, Player_l_weapon_offsets_length, Player_l_weapon_offsets);
+    Player.animationTimer_address = FindPointerAddr(processHandle, player_base_add, Player_animationTimer_offsets_length, Player_animationTimer_offsets);
+    Player.animationTimer2_address = FindPointerAddr(processHandle, player_base_add, Player_animationTimer2_offsets_length, Player_animationTimer2_offsets);
+    Player.animationId_address = FindPointerAddr(processHandle, player_base_add, Player_animationID_offsets_length, Player_animationID_offsets);
+    Player.animationId2_address = FindPointerAddr(processHandle, player_base_add, Player_animationID2_offsets_length, Player_animationID2_offsets);
+    Player.hurtboxActive_address = 0;
+    Player.readyState_address = FindPointerAddr(processHandle, player_base_add, Player_readyState_offsets_length, Player_readyState_offsets);
+    Player.velocity_address = 0;
+    Player.locked_on_address = FindPointerAddr(processHandle, player_base_add, Player_Lock_on_offsets_length, Player_Lock_on_offsets);
+    Player.twoHanding_address = FindPointerAddr(processHandle, player_base_add, Player_twohanding_offsets_length, Player_twohanding_offsets);
+    Player.visualStatus_address = FindPointerAddr(processHandle, player_base_add, Player_visual_offsets_length, Player_visual_offsets);
 }

--- a/Dark Souls AI C/CharacterStruct.c
+++ b/Dark Souls AI C/CharacterStruct.c
@@ -4,6 +4,9 @@
 #pragma warning( disable: 4244 )//ignore dataloss conversion from double to float
 #pragma warning( disable: 4305 )
 
+ullong Enemy_base_add = 0x00F7DC70;
+ullong player_base_add = 0x00F7D644;
+
 #define WeaponGhostHitTime 0.21//NOTE: this is curently hardcoded for gold tracer until i find a dynamic way
 
 void ReadPlayer(Character * c, HANDLE processHandle, int characterId){

--- a/Dark Souls AI C/CharacterStruct.h
+++ b/Dark Souls AI C/CharacterStruct.h
@@ -60,6 +60,9 @@ typedef struct {
     //if player is two handing or not
     ullong twoHanding_address;
     unsigned char twoHanding;
+    //player visual state. used for auto red signing
+    ullong visualStatus_address;
+    int visualStatus;
 } Character;
 
 //initalize the phantom and player
@@ -164,4 +167,7 @@ static const int Player_Lock_on_offsets_length = 5;
 //handed state of player
 static const int Player_twohanding_offsets[] = { 0x28, 0x0, 0x148, 0x4C8, 0x0 };
 static const int Player_twohanding_offsets_length = 5;
+//visual state of player (phantom, host, invader, etc)
+static const int Player_visual_offsets[] = { 0x28, 0x0, 0x30, 0xC, 0x70 };
+static const int Player_visual_offsets_length = 5;
 #endif

--- a/Dark Souls AI C/CharacterStruct.h
+++ b/Dark Souls AI C/CharacterStruct.h
@@ -81,8 +81,8 @@ void ReadPointerEndAddresses(HANDLE processHandle);
 //basic values and offsets we use
 //the base address, which offsets are added to
 //this MUST be 64 bits to account for max possible address space
-static ullong Enemy_base_add = 0x00F7DC70;
-static ullong player_base_add = 0x00F7D644;
+extern ullong Enemy_base_add;
+extern ullong player_base_add;
 //offsets and length for x location
 static const int Enemy_loc_x_offsets[] = { 0x4, 0x4, 0x2C, 0x260 };
 static const int Player_loc_x_offsets[] = { 0x3C, 0x330, 0x4, 0x20C, 0x3C0 };

--- a/Dark Souls AI C/CharacterStruct.h
+++ b/Dark Souls AI C/CharacterStruct.h
@@ -70,9 +70,11 @@ Character Enemy;
 Character Player;
 
 //read memory for the character's variables
-void ReadPlayer(Character * c, HANDLE * processHandle, int characterId);
+void ReadPlayer(Character * c, HANDLE processHandle, int characterId);
 
-void ReadPlayerDEBUGGING(Character * c, HANDLE * processHandle, ...);
+void ReadPlayerDEBUGGING(Character * c, HANDLE processHandle, ...);
+
+void ReadPointerEndAddresses(HANDLE processHandle);
 
 //TODO prune as many of these as possible. what needs to be kept for only one char?
 

--- a/Dark Souls AI C/Dark Souls AI C.vcxproj
+++ b/Dark Souls AI C/Dark Souls AI C.vcxproj
@@ -99,6 +99,7 @@
     <ClCompile Include="MemoryEdits.c" />
     <ClCompile Include="Source.c" />
     <ClCompile Include="SubRoutines.c" />
+    <ClCompile Include="vjoyhelper.c" />
     <ClCompile Include="WeaponData.c" />
   </ItemGroup>
   <ItemGroup>
@@ -114,6 +115,7 @@
     <ClInclude Include="public.h" />
     <ClInclude Include="Source.h" />
     <ClInclude Include="SubRoutines.h" />
+    <ClInclude Include="vjoyhelper.h" />
     <ClInclude Include="vjoyinterface.h" />
     <ClInclude Include="WeaponData.h" />
   </ItemGroup>

--- a/Dark Souls AI C/Dark Souls AI C.vcxproj.filters
+++ b/Dark Souls AI C/Dark Souls AI C.vcxproj.filters
@@ -67,9 +67,6 @@
     <ClCompile Include="gui.c">
       <Filter>GUI</Filter>
     </ClCompile>
-    <ClCompile Include="TestSpace.c">
-      <Filter>CharacterUtils</Filter>
-    </ClCompile>
     <ClCompile Include="Memory.c">
       <Filter>AICore\Memory</Filter>
     </ClCompile>
@@ -81,6 +78,9 @@
     </ClCompile>
     <ClCompile Include="HelperUtil.c">
       <Filter>HelperUtils</Filter>
+    </ClCompile>
+    <ClCompile Include="TestSpace.c">
+      <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>
@@ -121,6 +121,9 @@
       <Filter>Source Files</Filter>
     </ClInclude>
     <ClInclude Include="HelperUtil.h">
+      <Filter>HelperUtils</Filter>
+    </ClInclude>
+    <ClInclude Include="WeaponData.h">
       <Filter>HelperUtils</Filter>
     </ClInclude>
   </ItemGroup>

--- a/Dark Souls AI C/Dark Souls AI C.vcxproj.filters
+++ b/Dark Souls AI C/Dark Souls AI C.vcxproj.filters
@@ -82,6 +82,9 @@
     <ClCompile Include="TestSpace.c">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="vjoyhelper.c">
+      <Filter>VJoy</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="MemoryEdits.h">
@@ -125,6 +128,9 @@
     </ClInclude>
     <ClInclude Include="WeaponData.h">
       <Filter>HelperUtils</Filter>
+    </ClInclude>
+    <ClInclude Include="vjoyhelper.h">
+      <Filter>VJoy</Filter>
     </ClInclude>
   </ItemGroup>
 </Project>

--- a/Dark Souls AI C/Handler.c
+++ b/Dark Souls AI C/Handler.c
@@ -7,8 +7,17 @@ void BlackCrystalOut(){
     iReport.bHats = 0x0;
     iReport.lButtons = square;
     Sleep(100);
+    iReport.bHats = 0x1;//down d pad again to go back to red sign
     iReport.lButtons = 0x0;
-    Sleep(1000);
+    Sleep(100);
+    iReport.bHats = 0x0;
+    Sleep(10000);//TODO time is however long it takes to black crystal
+}
+
+void PutDownRedSign(){
+    iReport.lButtons = square;
+    Sleep(100);
+    iReport.lButtons = 0x0;
 }
 
 int main(void){
@@ -22,11 +31,13 @@ int main(void){
             MainLogicLoop();
         }
         //if enemy player far away, black crystal out
-        else if (distance(&Player, &Enemy) < 100){
+        else if (Player.visualStatus == 2 && distance(&Player, &Enemy) > 100){
             BlackCrystalOut();
         }
-        //if AI in host world, and red sign not down, put down red sign
-
+        //if AI in host world, and TODO red sign not down, put down red sign
+        else if (Player.visualStatus == 0){
+            PutDownRedSign();
+        }
     }
 
     Exit();

--- a/Dark Souls AI C/Handler.c
+++ b/Dark Souls AI C/Handler.c
@@ -31,6 +31,8 @@ void PutDownRedSign(){
     RedSignDown = true;
 }
 
+static bool RereadPointerEndAddress = true;
+
 int main(void){
     if (SetupandLoad()){
         return EXIT_FAILURE;
@@ -39,25 +41,31 @@ int main(void){
     while (1){
         ReadProcessMemory(processHandle, (LPCVOID)(Player.visualStatus_address), &(Player.visualStatus), 4, 0);//this memory read isnt directly AI related
 
+        if (RereadPointerEndAddress){
+            ReadPointerEndAddresses(processHandle);
+        }
+
         //if AI is a red phantom
         if (Player.visualStatus == 2){
             RedSignDown = false;
+            RereadPointerEndAddress = false;
             //enemy player is fairly close
             if(distance(&Player, &Enemy) < 50){
                 MainLogicLoop();
+                //once we die
+                if (Player.hp <= 0){
+                    RereadPointerEndAddress = true;
+                }
             }
             //if enemy player far away, black crystal out
             else{
+                RereadPointerEndAddress = true;
                 BlackCrystalOut();
             }
         }
         //if AI in host world, and red sign not down, put down red sign
         else if (Player.visualStatus == 0 && !RedSignDown){
             PutDownRedSign();
-        }
-        //i know this is dirty, but it feels so clean.
-        else if (Player.visualStatus != 0 && Player.visualStatus != 2){
-            ReadPointerEndAddresses(processHandle);
         }
     }
 

--- a/Dark Souls AI C/Handler.c
+++ b/Dark Souls AI C/Handler.c
@@ -1,13 +1,32 @@
 #include "Source.h"
 #include <stdlib.h>
 
+void BlackCrystalOut(){
+    iReport.bHats = 0x1;//down d pad
+    Sleep(100);
+    iReport.bHats = 0x0;
+    iReport.lButtons = square;
+    Sleep(100);
+    iReport.lButtons = 0x0;
+    Sleep(1000);
+}
+
 int main(void){
     if (SetupandLoad()){
         return EXIT_FAILURE;
     }
 
     while (1){
-        MainLogicLoop();
+        //if AI is a red phantom and enemy player is fairly close
+        if (Player.visualStatus == 2 && distance(&Player, &Enemy) < 100){
+            MainLogicLoop();
+        }
+        //if enemy player far away, black crystal out
+        else if (distance(&Player, &Enemy) < 100){
+            BlackCrystalOut();
+        }
+        //if AI in host world, and red sign not down, put down red sign
+
     }
 
     Exit();

--- a/Dark Souls AI C/Handler.c
+++ b/Dark Souls AI C/Handler.c
@@ -3,27 +3,35 @@
 
 void BlackCrystalOut(){
     ResetVJoyController();
+    //switch to black crystal
     iReport.bHats = ddown;
     UpdateVJD(iInterface, (PVOID)&iReport);
     Sleep(1000);//gotta wait for menu to change
-
+    //use
     iReport.bHats = dcenter;
     iReport.lButtons = square;
     UpdateVJD(iInterface, (PVOID)&iReport);
     Sleep(100);
-
+    //yes i want to leave
     iReport.lButtons = cross;
     UpdateVJD(iInterface, (PVOID)&iReport);
     Sleep(100);
-
-    iReport.bHats = ddown;//down d pad again to go back to red sign
+    //ok i left
     iReport.lButtons = 0x0;
     UpdateVJD(iInterface, (PVOID)&iReport);
-
     Sleep(100);
+    iReport.lButtons = cross;
+    UpdateVJD(iInterface, (PVOID)&iReport);
+    Sleep(100);
+    //down d pad again to go back to red sign
+    iReport.bHats = ddown;
+    iReport.lButtons = 0x0;
+    UpdateVJD(iInterface, (PVOID)&iReport);
+    Sleep(100);
+    //wait
     iReport.bHats = dcenter;
     UpdateVJD(iInterface, (PVOID)&iReport);
-    Sleep(5000);//10 sec is how long it takes to black crystal
+    Sleep(10000);//10 sec is how long it takes to black crystal
 }
 
 static bool RedSignDown = false;
@@ -46,21 +54,18 @@ int main(void){
     }
 
     while (1){
-        ReadProcessMemory(processHandle, (LPCVOID)(Player.visualStatus_address), &(Player.visualStatus), 4, 0);//this memory read isnt directly AI related
-
         if (RereadPointerEndAddress){
             ReadPointerEndAddresses(processHandle);
+            ReadPlayer(&Enemy, processHandle, LocationMemoryEnemy);
+            ReadPlayer(&Player, processHandle, LocationMemoryPlayer);
         }
+        ReadProcessMemory(processHandle, (LPCVOID)(Player.visualStatus_address), &(Player.visualStatus), 4, 0);//this memory read isnt directly AI related
 
         //if AI is a red phantom
         if (Player.visualStatus == 2){
             //enemy player is fairly close
             if(distance(&Player, &Enemy) < 50){
                 MainLogicLoop();
-                //once we die
-                if (Player.hp <= 0){
-                    RereadPointerEndAddress = true;
-                }
             }
             //if enemy player far away, black crystal out
             else{
@@ -73,9 +78,14 @@ int main(void){
             if (Enemy.loc_x > 0){
                 RereadPointerEndAddress = false;
             }
+            //once one character dies
+            if (Player.hp <= 0 || Enemy.hp <= 0){
+                RereadPointerEndAddress = true;
+            }
         }
         //if AI in host world, and red sign not down, put down red sign
         else if (Player.visualStatus == 0 && !RedSignDown){
+            Sleep(10000);//ensure we're out of loading screen
             PutDownRedSign();
         }
     }

--- a/Dark Souls AI C/Handler.c
+++ b/Dark Souls AI C/Handler.c
@@ -26,6 +26,8 @@ int main(void){
     }
 
     while (1){
+        ReadProcessMemory(processHandle, (LPCVOID)(Player.visualStatus_address), &(Player.visualStatus), 4, 0);//this memory read isnt directly AI related
+
         //if AI is a red phantom and enemy player is fairly close
         if (Player.visualStatus == 2 && distance(&Player, &Enemy) < 100){
             MainLogicLoop();

--- a/Dark Souls AI C/Handler.c
+++ b/Dark Souls AI C/Handler.c
@@ -3,20 +3,27 @@
 
 void BlackCrystalOut(){
     ResetVJoyController();
-    iReport.bHats = 0x1;//down d pad
+    iReport.bHats = ddown;
     UpdateVJD(iInterface, (PVOID)&iReport);
-    Sleep(100);
-    iReport.bHats = 0x0;
+    Sleep(1000);//gotta wait for menu to change
+
+    iReport.bHats = dcenter;
     iReport.lButtons = square;
     UpdateVJD(iInterface, (PVOID)&iReport);
     Sleep(100);
-    iReport.bHats = 0x1;//down d pad again to go back to red sign
-    iReport.lButtons = 0x0;
+
+    iReport.lButtons = cross;
     UpdateVJD(iInterface, (PVOID)&iReport);
     Sleep(100);
-    iReport.bHats = 0x0;
+
+    iReport.bHats = ddown;//down d pad again to go back to red sign
+    iReport.lButtons = 0x0;
     UpdateVJD(iInterface, (PVOID)&iReport);
-    Sleep(10000);//TODO time is however long it takes to black crystal
+
+    Sleep(100);
+    iReport.bHats = dcenter;
+    UpdateVJD(iInterface, (PVOID)&iReport);
+    Sleep(5000);//10 sec is how long it takes to black crystal
 }
 
 static bool RedSignDown = false;
@@ -47,8 +54,6 @@ int main(void){
 
         //if AI is a red phantom
         if (Player.visualStatus == 2){
-            RedSignDown = false;
-            RereadPointerEndAddress = false;
             //enemy player is fairly close
             if(distance(&Player, &Enemy) < 50){
                 MainLogicLoop();
@@ -61,6 +66,12 @@ int main(void){
             else{
                 RereadPointerEndAddress = true;
                 BlackCrystalOut();
+            }
+
+            RedSignDown = false;
+            //check that we got the enemy's struct address by ensuring their x loc is pos.
+            if (Enemy.loc_x > 0){
+                RereadPointerEndAddress = false;
             }
         }
         //if AI in host world, and red sign not down, put down red sign

--- a/Dark Souls AI C/Handler.c
+++ b/Dark Souls AI C/Handler.c
@@ -2,7 +2,7 @@
 #include <stdlib.h>
 
 void BlackCrystalOut(){
-    ResetAll();
+    ResetVJoyController();
     iReport.bHats = 0x1;//down d pad
     UpdateVJD(iInterface, (PVOID)&iReport);
     Sleep(100);
@@ -22,7 +22,7 @@ void BlackCrystalOut(){
 static bool RedSignDown = false;
 
 void PutDownRedSign(){
-    ResetAll();
+    ResetVJoyController();
     iReport.lButtons = square;
     UpdateVJD(iInterface, (PVOID)&iReport);
     Sleep(100);

--- a/Dark Souls AI C/Handler.c
+++ b/Dark Souls AI C/Handler.c
@@ -13,16 +13,12 @@ void BlackCrystalOut(){
     UpdateVJD(iInterface, (PVOID)&iReport);
     Sleep(100);
     //yes i want to leave
-    iReport.lButtons = cross;
-    UpdateVJD(iInterface, (PVOID)&iReport);
-    Sleep(100);
-    //ok i left
     iReport.lButtons = 0x0;
     UpdateVJD(iInterface, (PVOID)&iReport);
     Sleep(100);
     iReport.lButtons = cross;
     UpdateVJD(iInterface, (PVOID)&iReport);
-    Sleep(100);
+    Sleep(500);
     //down d pad again to go back to red sign
     iReport.bHats = ddown;
     iReport.lButtons = 0x0;

--- a/Dark Souls AI C/Handler.c
+++ b/Dark Souls AI C/Handler.c
@@ -3,21 +3,30 @@
 
 void BlackCrystalOut(){
     iReport.bHats = 0x1;//down d pad
+    UpdateVJD(iInterface, (PVOID)&iReport);
     Sleep(100);
     iReport.bHats = 0x0;
     iReport.lButtons = square;
+    UpdateVJD(iInterface, (PVOID)&iReport);
     Sleep(100);
     iReport.bHats = 0x1;//down d pad again to go back to red sign
     iReport.lButtons = 0x0;
+    UpdateVJD(iInterface, (PVOID)&iReport);
     Sleep(100);
     iReport.bHats = 0x0;
+    UpdateVJD(iInterface, (PVOID)&iReport);
     Sleep(10000);//TODO time is however long it takes to black crystal
 }
 
+static bool RedSignDown = false;
+
 void PutDownRedSign(){
     iReport.lButtons = square;
+    UpdateVJD(iInterface, (PVOID)&iReport);
     Sleep(100);
     iReport.lButtons = 0x0;
+    UpdateVJD(iInterface, (PVOID)&iReport);
+    RedSignDown = true;
 }
 
 int main(void){
@@ -28,16 +37,20 @@ int main(void){
     while (1){
         ReadProcessMemory(processHandle, (LPCVOID)(Player.visualStatus_address), &(Player.visualStatus), 4, 0);//this memory read isnt directly AI related
 
-        //if AI is a red phantom and enemy player is fairly close
-        if (Player.visualStatus == 2 && distance(&Player, &Enemy) < 100){
-            MainLogicLoop();
+        //if AI is a red phantom
+        if (Player.visualStatus == 2){
+            RedSignDown = false;
+            //enemy player is fairly close
+            if(distance(&Player, &Enemy) < 50){
+                MainLogicLoop();
+            }
+            //if enemy player far away, black crystal out
+            else{
+                BlackCrystalOut();
+            }
         }
-        //if enemy player far away, black crystal out
-        else if (Player.visualStatus == 2 && distance(&Player, &Enemy) > 100){
-            BlackCrystalOut();
-        }
-        //if AI in host world, and TODO red sign not down, put down red sign
-        else if (Player.visualStatus == 0){
+        //if AI in host world, and red sign not down, put down red sign
+        else if (Player.visualStatus == 0 && !RedSignDown){
             PutDownRedSign();
         }
     }

--- a/Dark Souls AI C/Handler.c
+++ b/Dark Souls AI C/Handler.c
@@ -2,6 +2,7 @@
 #include <stdlib.h>
 
 void BlackCrystalOut(){
+    ResetAll();
     iReport.bHats = 0x1;//down d pad
     UpdateVJD(iInterface, (PVOID)&iReport);
     Sleep(100);
@@ -21,6 +22,7 @@ void BlackCrystalOut(){
 static bool RedSignDown = false;
 
 void PutDownRedSign(){
+    ResetAll();
     iReport.lButtons = square;
     UpdateVJD(iInterface, (PVOID)&iReport);
     Sleep(100);
@@ -52,6 +54,10 @@ int main(void){
         //if AI in host world, and red sign not down, put down red sign
         else if (Player.visualStatus == 0 && !RedSignDown){
             PutDownRedSign();
+        }
+        //i know this is dirty, but it feels so clean.
+        else if (Player.visualStatus != 0 && Player.visualStatus != 2){
+            ReadPointerEndAddresses(processHandle);
         }
     }
 

--- a/Dark Souls AI C/HelperUtil.h
+++ b/Dark Souls AI C/HelperUtil.h
@@ -35,6 +35,11 @@ int loadvJoy(UINT iInterface);
 #define r3 0x200
 #define select 0x400
 #define start 0x800
+#define dup 0x0
+#define dright 0x1
+#define ddown 0x2
+#define dleft 0x3
+#define dcenter 0x4
 
 typedef struct{
 	long first;

--- a/Dark Souls AI C/MindRoutines.c
+++ b/Dark Souls AI C/MindRoutines.c
@@ -82,8 +82,9 @@ DWORD WINAPI AttackMindProcess(void* data){
         if (
             (Player.stamina > 90) &&  //have enough stamina
             (Enemy.subanimation >= LockInSubanimation) &&  //enemy in vulnerable state
-            (rand()<RAND_MAX/5) &&                              //random limitor
-            (distanceInput > 1)  //dont attack when right in enemy face to try and avoid getting parried
+            distanceInput <= Player.weaponRange &&  //in range
+            (distanceInput > 1 &&  //dont attack when right in enemy face to try and avoid getting parried
+            (rand()<RAND_MAX / 5)) //random limitor
            ){
             AttackChoice = GhostHitId;
         }

--- a/Dark Souls AI C/Source.c
+++ b/Dark Souls AI C/Source.c
@@ -5,7 +5,6 @@
 
 //vjoy settings/variables
 #pragma comment( lib, "VJOYINTERFACE" )//load vjoy library
-#define iInterface 1// Default target vJoy device
 JOYSTICK_POSITION iReport;
 
 //neural net and desicion making settings/variables
@@ -81,6 +80,15 @@ int SetupandLoad(){
         return loadresult;
     }
     iReport.bDevice = (BYTE)iInterface;
+
+    // reset struct info
+    iReport.wAxisX = MIDDLE;
+    iReport.wAxisY = MIDDLE;
+    iReport.wAxisZ = MIDDLE;//this is l2 and r2
+    iReport.wAxisYRot = MIDDLE;
+    iReport.wAxisXRot = MIDDLE;
+    iReport.lButtons = 0x0;
+    iReport.bHats = 0x0;//d-pad
 
     //load neural network and threads
     int error = ReadyThreads();

--- a/Dark Souls AI C/Source.c
+++ b/Dark Souls AI C/Source.c
@@ -54,6 +54,7 @@ int SetupandLoad(){
     Enemy.velocity_address = FindPointerAddr(processHandle, Enemy_base_add, Enemy_velocity_offsets_length, Enemy_velocity_offsets);
     Enemy.locked_on_address = 0;
     Enemy.twoHanding_address = 0;
+    Enemy.visualStatus_address = 0;
 
     Player.location_x_address = FindPointerAddr(processHandle, player_base_add, Player_loc_x_offsets_length, Player_loc_x_offsets);
     Player.location_y_address = FindPointerAddr(processHandle, player_base_add, Player_loc_y_offsets_length, Player_loc_y_offsets);
@@ -72,6 +73,7 @@ int SetupandLoad(){
     Player.velocity_address = 0;
     Player.locked_on_address = FindPointerAddr(processHandle, player_base_add, Player_Lock_on_offsets_length, Player_Lock_on_offsets);
     Player.twoHanding_address = FindPointerAddr(processHandle, player_base_add, Player_twohanding_offsets_length, Player_twohanding_offsets);
+    Player.visualStatus_address = FindPointerAddr(processHandle, player_base_add, Player_visual_offsets_length, Player_visual_offsets);
 
     //want to use controller input, instead of keyboard, as analog stick is more precise movement
     int loadresult = loadvJoy(iInterface);

--- a/Dark Souls AI C/Source.c
+++ b/Dark Souls AI C/Source.c
@@ -41,7 +41,7 @@ int SetupandLoad(){
         return loadresult;
     }
     iReport.bDevice = (BYTE)iInterface;
-    ResetAll();
+    ResetVJoyController();
 
     //load neural network and threads
     int error = ReadyThreads();
@@ -79,7 +79,7 @@ void MainLogicLoop(){
         WakeThread(defense_mind_input);
         WakeThread(attack_mind_input);
 
-        ResetAll();//reset vjoy struct
+        ResetVJoyController();
 
 		//begin reading enemy state, and handle w logic and subroutines
         char attackImminent = EnemyStateProcessing(&Player, &Enemy);

--- a/Dark Souls AI C/Source.c
+++ b/Dark Souls AI C/Source.c
@@ -33,46 +33,7 @@ int SetupandLoad(){
     Enemy_base_add += memorybase;
     player_base_add += memorybase;
 
-    //TODO THESE HAVE TO BE REREAD, AS THE END ADDRESS CAN CHANGE
-    //MOVE TO SETUP METHOD in CharacterStruct
-    //add the pointer offsets to the address. This can be slow because its startup only
-    Enemy.location_x_address = FindPointerAddr(processHandle, Enemy_base_add, Enemy_loc_x_offsets_length, Enemy_loc_x_offsets);
-    Enemy.location_y_address = FindPointerAddr(processHandle, Enemy_base_add, Enemy_loc_y_offsets_length, Enemy_loc_y_offsets);
-    Enemy.rotation_address = FindPointerAddr(processHandle, Enemy_base_add, Enemy_rotation_offsets_length, Enemy_rotation_offsets);
-    Enemy.animationType_address = FindPointerAddr(processHandle, Enemy_base_add, Enemy_animationType_offsets_length, Enemy_animationType_offsets);
-    Enemy.hp_address = FindPointerAddr(processHandle, Enemy_base_add, Enemy_hp_offsets_length, Enemy_hp_offsets);
-    Enemy.stamina_address = 0;
-    Enemy.r_weapon_address = FindPointerAddr(processHandle, Enemy_base_add, Enemy_r_weapon_offsets_length, Enemy_r_weapon_offsets);
-    Enemy.l_weapon_address = FindPointerAddr(processHandle, Enemy_base_add, Enemy_l_weapon_offsets_length, Enemy_l_weapon_offsets);
-    Enemy.animationTimer_address = FindPointerAddr(processHandle, Enemy_base_add, Enemy_animationTimer_offsets_length, Enemy_animationTimer_offsets);
-    Enemy.animationTimer2_address = FindPointerAddr(processHandle, Enemy_base_add, Enemy_animationTimer2_offsets_length, Enemy_animationTimer2_offsets);
-    Enemy.animationId_address = FindPointerAddr(processHandle, Enemy_base_add, Enemy_animationID_offsets_length, Enemy_animationID_offsets);
-    Enemy.animationId2_address = FindPointerAddr(processHandle, Enemy_base_add, Enemy_animationID2_offsets_length, Enemy_animationID2_offsets);
-    Enemy.hurtboxActive_address = FindPointerAddr(processHandle, Enemy_base_add, Enemy_hurtboxActive_offsets_length, Enemy_hurtboxActive_offsets);
-    Enemy.readyState_address = 0;
-    Enemy.velocity_address = FindPointerAddr(processHandle, Enemy_base_add, Enemy_velocity_offsets_length, Enemy_velocity_offsets);
-    Enemy.locked_on_address = 0;
-    Enemy.twoHanding_address = 0;
-    Enemy.visualStatus_address = 0;
-
-    Player.location_x_address = FindPointerAddr(processHandle, player_base_add, Player_loc_x_offsets_length, Player_loc_x_offsets);
-    Player.location_y_address = FindPointerAddr(processHandle, player_base_add, Player_loc_y_offsets_length, Player_loc_y_offsets);
-    Player.rotation_address = FindPointerAddr(processHandle, player_base_add, Player_rotation_offsets_length, Player_rotation_offsets);
-    Player.animationType_address = FindPointerAddr(processHandle, player_base_add, Player_animationType_offsets_length, Player_animationType_offsets);
-    Player.hp_address = FindPointerAddr(processHandle, player_base_add, Player_hp_offsets_length, Player_hp_offsets);
-    Player.stamina_address = FindPointerAddr(processHandle, player_base_add, Player_stamina_offsets_length, Player_stamina_offsets);
-    Player.r_weapon_address = FindPointerAddr(processHandle, player_base_add, Player_r_weapon_offsets_length, Player_r_weapon_offsets);
-    Player.l_weapon_address = FindPointerAddr(processHandle, player_base_add, Player_l_weapon_offsets_length, Player_l_weapon_offsets);
-    Player.animationTimer_address = FindPointerAddr(processHandle, player_base_add, Player_animationTimer_offsets_length, Player_animationTimer_offsets);
-    Player.animationTimer2_address = FindPointerAddr(processHandle, player_base_add, Player_animationTimer2_offsets_length, Player_animationTimer2_offsets);
-    Player.animationId_address = FindPointerAddr(processHandle, player_base_add, Player_animationID_offsets_length, Player_animationID_offsets);
-    Player.animationId2_address = FindPointerAddr(processHandle, player_base_add, Player_animationID2_offsets_length, Player_animationID2_offsets);
-    Player.hurtboxActive_address = 0;
-    Player.readyState_address = FindPointerAddr(processHandle, player_base_add, Player_readyState_offsets_length, Player_readyState_offsets);
-    Player.velocity_address = 0;
-    Player.locked_on_address = FindPointerAddr(processHandle, player_base_add, Player_Lock_on_offsets_length, Player_Lock_on_offsets);
-    Player.twoHanding_address = FindPointerAddr(processHandle, player_base_add, Player_twohanding_offsets_length, Player_twohanding_offsets);
-    Player.visualStatus_address = FindPointerAddr(processHandle, player_base_add, Player_visual_offsets_length, Player_visual_offsets);
+    ReadPointerEndAddresses(processHandle);
 
     //want to use controller input, instead of keyboard, as analog stick is more precise movement
     int loadresult = loadvJoy(iInterface);
@@ -80,15 +41,7 @@ int SetupandLoad(){
         return loadresult;
     }
     iReport.bDevice = (BYTE)iInterface;
-
-    // reset struct info
-    iReport.wAxisX = MIDDLE;
-    iReport.wAxisY = MIDDLE;
-    iReport.wAxisZ = MIDDLE;//this is l2 and r2
-    iReport.wAxisYRot = MIDDLE;
-    iReport.wAxisXRot = MIDDLE;
-    iReport.lButtons = 0x0;
-    iReport.bHats = 0x0;//d-pad
+    ResetAll();
 
     //load neural network and threads
     int error = ReadyThreads();
@@ -119,21 +72,14 @@ void MainLogicLoop(){
 		//lockCamera(&processHandle);
 
 		//read the data at these pointers, now that offsets have been added and we have a static address
-        ReadPlayer(&Enemy, &processHandle, LocationMemoryEnemy);
-        ReadPlayer(&Player, &processHandle, LocationMemoryPlayer);
+        ReadPlayer(&Enemy, processHandle, LocationMemoryEnemy);
+        ReadPlayer(&Player, processHandle, LocationMemoryPlayer);
 
         //start the neural network threads
         WakeThread(defense_mind_input);
         WakeThread(attack_mind_input);
 
-		// reset struct info
-		iReport.wAxisX = MIDDLE;
-		iReport.wAxisY = MIDDLE;
-		iReport.wAxisZ = MIDDLE;//this is l2 and r2
-		iReport.wAxisYRot = MIDDLE;
-		iReport.wAxisXRot = MIDDLE;
-        iReport.lButtons = 0x0;
-        iReport.bHats = 0x0;//d-pad
+        ResetAll();//reset vjoy struct
 
 		//begin reading enemy state, and handle w logic and subroutines
         char attackImminent = EnemyStateProcessing(&Player, &Enemy);

--- a/Dark Souls AI C/Source.h
+++ b/Dark Souls AI C/Source.h
@@ -12,6 +12,8 @@
 #include "fann.h"
 
 extern HANDLE processHandle;
+
+#define iInterface 1// Default target vJoy device
 extern JOYSTICK_POSITION iReport;
 
 int SetupandLoad();

--- a/Dark Souls AI C/Source.h
+++ b/Dark Souls AI C/Source.h
@@ -12,6 +12,7 @@
 #include "fann.h"
 
 extern HANDLE processHandle;
+extern JOYSTICK_POSITION iReport;
 
 int SetupandLoad();
 

--- a/Dark Souls AI C/Source.h
+++ b/Dark Souls AI C/Source.h
@@ -8,6 +8,7 @@
 #include "AIMethods.h"
 #include "SubRoutines.h"
 #include "MindRoutines.h"
+#include "vjoyhelper.h"
 
 #include "fann.h"
 

--- a/Dark Souls AI C/vjoyhelper.c
+++ b/Dark Souls AI C/vjoyhelper.c
@@ -1,0 +1,14 @@
+#include "vjoyhelper.h"
+
+extern JOYSTICK_POSITION iReport;
+
+void ResetVJoyController(){
+    // reset struct info
+    iReport.wAxisX = MIDDLE;
+    iReport.wAxisY = MIDDLE;
+    iReport.wAxisZ = MIDDLE;//this is l2 and r2
+    iReport.wAxisYRot = MIDDLE;
+    iReport.wAxisXRot = MIDDLE;
+    iReport.lButtons = 0x0;
+    iReport.bHats = 0x0;//d-pad
+}

--- a/Dark Souls AI C/vjoyhelper.c
+++ b/Dark Souls AI C/vjoyhelper.c
@@ -10,5 +10,5 @@ void ResetVJoyController(){
     iReport.wAxisYRot = MIDDLE;
     iReport.wAxisXRot = MIDDLE;
     iReport.lButtons = 0x0;
-    iReport.bHats = 0x0;//d-pad
+    iReport.bHats = dcenter;//d-pad center
 }

--- a/Dark Souls AI C/vjoyhelper.h
+++ b/Dark Souls AI C/vjoyhelper.h
@@ -1,0 +1,8 @@
+#ifndef VJOYHELPER_H
+#define VJOYHELPER_H
+
+#include "HelperUtil.h"
+
+void ResetVJoyController();
+
+#endif

--- a/Dark Souls AI gui/src/GUI.java
+++ b/Dark Souls AI gui/src/GUI.java
@@ -21,10 +21,10 @@ class GuiPane extends JPanel{
     private int height;
 
     private JPanel MemoryEnemy=new JPanel();
-    private JTextArea[] MemoryEnemy_Params=new JTextArea[12];
+    private JTextArea[] MemoryEnemy_Params=new JTextArea[15];
     
     private JPanel MemoryPlayer=new JPanel();
-    private JTextArea[] MemoryPlayer_Params=new JTextArea[13];
+    private JTextArea[] MemoryPlayer_Params=new JTextArea[15];
 
     private JPanel Detection=new JPanel();
     private JTextArea[] Detection_Params=new JTextArea[6];


### PR DESCRIPTION
Fully automate the process of allowing AI to be summoned, for purpose of streaming.

- [x]  Put down red sign
- [x]  Detect if summoned
- [x] turn on AI if summoned and fairly close to enemy
- [x] black crystal out if summoned and enemy far away.
- [x] Fix the crashing bug with lock camera rotate. Fixed. AOB scan `F3 0F 11 83 44 01 00 00 80 BB 63 02 00 00 00`, noop, then lock camera x normally.